### PR TITLE
Prioritise indentation from CLI

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,3 +9,5 @@
     - pre-merge-commit
     - pre-push
     - manual
+  args:
+    - --log-level=DEBUG

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,5 +9,3 @@
     - pre-merge-commit
     - pre-push
     - manual
-  args:
-    - --log-level=DEBUG


### PR DESCRIPTION
When the indentation is set from the CLI arguments, respect it. Otherwise, and by default, use the indentation from the editorconfig settings, if any. This default behaviour is controlled through a negative indentation. Whenever no indentation can be found, default to the constant in the implementation, i.e. 2 (matches the one in lxml).

Close #1 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## (Edited) Summary by CodeRabbit


- **Refactor**
	- Improved handling of indentation width in XML formatting, including better default setting and enhanced logging messages for clarity.
	- Added a function to retrieve indentation style and size from `.editorconfig` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->